### PR TITLE
Add dispatcher to workflow

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -1,4 +1,4 @@
-name: Build kind node image
+name: Build kind node image and dispatch new tests
 
 on:
   workflow_dispatch:
@@ -60,3 +60,17 @@ jobs:
         run: bash run-kind.sh
       - name: Release node image
         run: bash release-image.sh
+  dispatch:
+    needs: build-kind-node-image
+    strategy:
+      matrix:
+        repo: ['storageos/kubectl-storageos', 'storageos/operator', 'storageos/node-manager', 'storageos/upgrade-guard']
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ matrix.repo }}
+          event-type: generate-tests
+          client-payload: '{"latest-kind-node": "${{ github.event.inputs.k8sVersion }}"}'

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -24,6 +24,11 @@ on:
         description: kind git repo branch to build kind from
         default: "main"
         required: true
+      createKuttlPRs:
+        description: Auto-generate PRs for kuttl test files relevant to this image
+        default: "true"
+        required: true
+
 
 env:
   K8S_GIT_REPO_BRANCH: ${{ github.event.inputs.k8sGitBranch }}
@@ -61,6 +66,7 @@ jobs:
       - name: Release node image
         run: bash release-image.sh
   dispatch:
+    if: ${{ github.event.inputs.createKuttlPRs == 'true' }}
     needs: build-kind-node-image
     strategy:
       matrix:


### PR DESCRIPTION
On each trigger of build workflow, we will now also auto-generate PRs in relevant repos with newly generated e2e test files relevant to the new kind-node image.

Participating repos:
- kubectl-storageos: https://github.com/storageos/kubectl-storageos/pull/119
- operator: https://github.com/storageos/operator/pull/92
- node-manager: https://github.com/storageos/node-manager/pull/17
- upgrade-guard: https://github.com/storageos/upgrade-guard/pull/11
- portal-manager: https://github.com/storageos/portal-manager/pull/41

(Trying out on kubectl-storageos repo first, will expand to others once any teething issues are solved)